### PR TITLE
Fix PrimeSense compilation errors

### DIFF
--- a/FriedLiver/Source/PrimeSenseSensor.h
+++ b/FriedLiver/Source/PrimeSenseSensor.h
@@ -32,10 +32,14 @@ public:
 	bool processDepth();
 	
 
-	//! Processes the Kinect color data
+	//! Processes the PrimeSense color data
 	bool processColor()
 	{
 		return true;
+	}
+	
+	std::string getSensorName() const {
+		return "PrimeSense";
 	}
 
 protected:


### PR DESCRIPTION
If compiling with OPEN_NI enabled, you will get an error because virtual function getSensorName of PrimeSenseSensor is not implemented. Fixed this.